### PR TITLE
Bootstrap 5 integration with compatibility fixes

### DIFF
--- a/ACS-Frontend/angular.json
+++ b/ACS-Frontend/angular.json
@@ -32,9 +32,7 @@
               "node_modules/bootstrap/dist/css/bootstrap.min.css"
             ],
             "scripts": [
-              "node_modules/jquery/dist/jquery.slim.min.js",
-              "node_modules/popper.js/dist/umd/popper.min.js",
-              "node_modules/bootstrap/dist/js/bootstrap.min.js"
+              "node_modules/bootstrap/dist/js/bootstrap.bundle.min.js"
             ]
           },
           "configurations": {
@@ -87,9 +85,7 @@
               "node_modules/bootstrap/dist/css/bootstrap.min.css"
             ],
             "scripts": [
-              "node_modules/jquery/dist/jquery.slim.min.js",
-              "node_modules/popper.js/dist/umd/popper.min.js",
-              "node_modules/bootstrap/dist/js/bootstrap.min.js"
+              "node_modules/bootstrap/dist/js/bootstrap.bundle.min.js"
             ],
             "assets": [
               "src/favicon.ico",

--- a/ACS-Frontend/package-lock.json
+++ b/ACS-Frontend/package-lock.json
@@ -18,11 +18,9 @@
         "@angular/platform-server": "^21.2.6",
         "@angular/router": "^21.2.6",
         "@angular/service-worker": "^21.2.6",
-        "bootstrap": "^4.6.2",
+        "bootstrap": "^5.0.0",
         "chart.js": "^2.9.4",
         "core-js": "^3.46.0",
-        "jquery": "^3.7.1",
-        "popper.js": "^1.14.4",
         "rxjs": "^7.8.2",
         "sass": "^1.98.0",
         "zone.js": "^0.15.1"
@@ -5516,6 +5514,17 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.4",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.4.tgz",
@@ -7231,10 +7240,9 @@
       "license": "ISC"
     },
     "node_modules/bootstrap": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.2.tgz",
-      "integrity": "sha512-51Bbp/Uxr9aTuy6ca/8FbFloBUJZLHwnhTcnjIeRn2suQWsWzcuJhGjKDB5eppVte/8oCdOL3VuwxvZDUggwGQ==",
-      "deprecated": "This version of Bootstrap is no longer supported. Please upgrade to the latest version.",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.8.tgz",
+      "integrity": "sha512-HP1SZDqaLDPwsNiqRqi5NcP0SSXciX2s9E+RyqJIIqGo+vJeN5AJVM98CXmW/Wux0nQ5L7jeWUdplCEf0Ee+tg==",
       "funding": [
         {
           "type": "github",
@@ -7245,9 +7253,9 @@
           "url": "https://opencollective.com/bootstrap"
         }
       ],
+      "license": "MIT",
       "peerDependencies": {
-        "jquery": "1.9.1 - 3",
-        "popper.js": "^1.16.1"
+        "@popperjs/core": "^2.11.8"
       }
     },
     "node_modules/brace-expansion": {
@@ -10412,11 +10420,6 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
-    "node_modules/jquery": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
-      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg=="
-    },
     "node_modules/js-yaml": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
@@ -12635,17 +12638,6 @@
       },
       "engines": {
         "node": ">=16.0.0"
-      }
-    },
-    "node_modules/popper.js": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
-      "deprecated": "You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/postcss": {
@@ -18738,6 +18730,12 @@
         "tsyringe": "^4.10.0"
       }
     },
+    "@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "peer": true
+    },
     "@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.4",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.4.tgz",
@@ -19877,9 +19875,9 @@
       "dev": true
     },
     "bootstrap": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.2.tgz",
-      "integrity": "sha512-51Bbp/Uxr9aTuy6ca/8FbFloBUJZLHwnhTcnjIeRn2suQWsWzcuJhGjKDB5eppVte/8oCdOL3VuwxvZDUggwGQ==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.8.tgz",
+      "integrity": "sha512-HP1SZDqaLDPwsNiqRqi5NcP0SSXciX2s9E+RyqJIIqGo+vJeN5AJVM98CXmW/Wux0nQ5L7jeWUdplCEf0Ee+tg==",
       "requires": {}
     },
     "brace-expansion": {
@@ -21940,11 +21938,6 @@
       "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
       "dev": true
     },
-    "jquery": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
-      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg=="
-    },
     "js-yaml": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
@@ -23438,11 +23431,6 @@
         "pvutils": "^1.1.3",
         "tslib": "^2.8.1"
       }
-    },
-    "popper.js": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ=="
     },
     "postcss": {
       "version": "8.5.6",

--- a/ACS-Frontend/package.json
+++ b/ACS-Frontend/package.json
@@ -21,11 +21,9 @@
     "@angular/platform-server": "^21.2.6",
     "@angular/router": "^21.2.6",
     "@angular/service-worker": "^21.2.6",
-    "bootstrap": "^4.6.2",
+    "bootstrap": "^5.0.0",
     "chart.js": "^2.9.4",
     "core-js": "^3.46.0",
-    "jquery": "^3.7.1",
-    "popper.js": "^1.14.4",
     "rxjs": "^7.8.2",
     "sass": "^1.98.0",
     "zone.js": "^0.15.1"

--- a/ACS-Frontend/src/app/form/lbasunit/lbasunit.component.html
+++ b/ACS-Frontend/src/app/form/lbasunit/lbasunit.component.html
@@ -2,7 +2,7 @@
   <div class="row">
     <form class="mx-auto my-3 border p-3 col-xs-12 col-sm-10 col-md-8">
       <div class="form-group d-flex" [ngClass]="{'mb-0': LBASCountValue === '0'}">
-        <label class="text-nowrap mr-3 mt-2" for="lbasCount">{{IndexString}}</label>
+        <label class="text-nowrap me-3 mt-2" for="lbasCount">{{IndexString}}</label>
         <select class="form-control" name="lbasCount" [(ngModel)]="LBASCountValue" (click)="calcRadiusAAV()">
           <option value="0">なし</option>
           <option value="1">分散</option>

--- a/ACS-Frontend/src/app/form/own-data/own-data.component.html
+++ b/ACS-Frontend/src/app/form/own-data/own-data.component.html
@@ -14,9 +14,9 @@
         </select>
       </div>
       <div class="form-group">
-        <span class="my-3 mr-3">制空値：{{AntiAirValue1}} / {{AntiAirValue2}}　判定：{{Status1}} / {{Status2}}</span><br>
-        <span class="my-3 mr-3">艦隊防空値：{{AntiAirBonus}}</span><br>
-        <span class="my-3 mr-3">加重対空値：{{WeightedAntiAir}}</span><br>
+        <span class="my-3 me-3">制空値：{{AntiAirValue1}} / {{AntiAirValue2}}　判定：{{Status1}} / {{Status2}}</span><br>
+        <span class="my-3 me-3">艦隊防空値：{{AntiAirBonus}}</span><br>
+        <span class="my-3 me-3">加重対空値：{{WeightedAntiAir}}</span><br>
         <button type="button" class="btn btn-primary p-1 mt-3" (click)="calcAAV()">制空値を更新</button>
       </div>
     </form>

--- a/ACS-Frontend/src/app/form/own-unit/own-unit.component.html
+++ b/ACS-Frontend/src/app/form/own-unit/own-unit.component.html
@@ -2,8 +2,8 @@
   <div class="row">
     <form class="mx-auto border p-3 col-xs-12 col-sm-10 col-md-8">
       <div class="form-group d-flex" [ngClass]="{'mb-0': KammusuNameValue === '0'}">
-        <label class="text-nowrap mr-3 mt-2" for="kammusuType">{{UnitString}}</label>
-        <select class="form-control mr-3 w-double-square" name="kammusuType" [(ngModel)]="KammusuTypeValue">
+        <label class="text-nowrap me-3 mt-2" for="kammusuType">{{UnitString}}</label>
+        <select class="form-control me-3 w-double-square" name="kammusuType" [(ngModel)]="KammusuTypeValue">
           <option *ngFor="let kammusuType of KammusuTypeList" [value]="kammusuType.value">{{kammusuType.name}}</option>
         </select>
         <select class="form-control" name="kammusuName" [(ngModel)]="KammusuNameValue">

--- a/ACS-Frontend/src/app/main/main.component.html
+++ b/ACS-Frontend/src/app/main/main.component.html
@@ -1,11 +1,11 @@
 <nav class="navbar navbar-expand-lg navbar-light bg-light">
   <a class="navbar-brand" href="#">航空戦シミュレーター</a>
   <button (click)="clearCache()">キャッシュクリア</button>
-  <button type="button" class="navbar-toggler" data-toggle="collapse" data-target="#Navber" aria-controls="Navber" aria-expanded="false" aria-label="ナビゲーションの切替">
+  <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#Navber" aria-controls="Navber" aria-expanded="false" aria-label="ナビゲーションの切替">
     <span class="navbar-toggler-icon"></span>
   </button>
   <div class="collapse navbar-collapse" id="Navber">
-    <ul class="navbar-nav mr-auto">
+    <ul class="navbar-nav me-auto">
       <li class="nav-item" [ngClass]="{'active bg-primary': Mode === 0}">
         <a class="nav-link" href="#" (click)="selectLBASMode()">基地航空隊</a>
       </li>

--- a/docs/security-remediation-log.md
+++ b/docs/security-remediation-log.md
@@ -87,3 +87,33 @@
   - After: npm audit vulnerabilities `0`
 - Remaining issues:
   - ビルド時の warning（unused ts entry / CommonJS dependency）は残るが、セキュリティ警告ではない
+
+## 2026-03-26 Batch 4: Bootstrap 5 integration validation branch
+- Targets:
+  - Integrate Dependabot PR #70 equivalent update (`bootstrap 4.6.2 -> 5.0.0`) on validation branch
+  - Absorb Bootstrap 4 -> 5 template compatibility changes in the same batch
+- Changes:
+  - Updated frontend dependency:
+    - `bootstrap: ^5.0.0`
+  - Reviewed jQuery/Popper handling and removed direct dependencies:
+    - removed `jquery` and `popper.js` from `ACS-Frontend/package.json`
+  - Updated Angular CLI script loading to Bootstrap 5 bundle:
+    - `bootstrap.bundle.min.js` only (removed jquery/popover script chain)
+  - Applied template compatibility fixes:
+    - `data-toggle` / `data-target` -> `data-bs-toggle` / `data-bs-target`
+    - `mr-*` / `mr-auto` -> `me-*` / `me-auto`
+- Verification:
+  - Frontend:
+    - `npm install`: success
+    - `npm audit`: `0` vulnerabilities
+    - `npm run build`: success
+    - `npm test -- --watch=false --browsers=ChromeHeadless`: success (`16 passed / 0 failed`)
+  - Server:
+    - `mvn test`: success
+    - `mvn package`: success
+- Alert counts:
+  - Before: Dependabot `0`, Code scanning `0`
+  - After: Dependabot `0`, Code scanning `0`
+- Remaining issues:
+  - Build-time warning（unused ts entry / CommonJS dependency）は継続（機能・セキュリティへの直接影響なし）
+  - Dependabot PR #70 はこの統合PRで吸収予定（重複回避で close）


### PR DESCRIPTION
## Summary
- Bootstrap を 4.6.2 から 5.0.0 へ更新
- Bootstrap 5 の互換対応としてテンプレート属性・ユーティリティクラスを更新
- jQuery / popper.js の直接依存を削除し、`bootstrap.bundle.min.js` に統一
- セキュリティ対応ログへ Batch 4 を追記

## Changes
- `ACS-Frontend/package.json`
  - `bootstrap` -> `^5.0.0`
  - `jquery`, `popper.js` を削除
- `ACS-Frontend/angular.json`
  - `scripts` を `bootstrap.bundle.min.js` のみへ変更（build/test 共通）
- Templates
  - `data-toggle` / `data-target` -> `data-bs-toggle` / `data-bs-target`
  - `mr-*` / `mr-auto` -> `me-*` / `me-auto`
- `docs/security-remediation-log.md`
  - Batch 4 追記

## Validation
- Frontend
  - `npm install` ✅
  - `npm audit` ✅ (0 vulnerabilities)
  - `npm run build` ✅
  - `npm test -- --watch=false --browsers=ChromeHeadless` ✅ (16 passed)
- Server
  - `mvn test` ✅
  - `mvn package` ✅

## Notes
- このPRは Dependabot #70（bootstrap 5更新提案）を吸収する目的です。